### PR TITLE
chore: Update DevCycle Deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.devcycle.devcycle_flutter_client_sdk'
 version '1.7.3'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.23'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,6 @@ android {
     }
 
     dependencies {
-        implementation("com.devcycle:android-client-sdk:2.0.5")
+        implementation("com.devcycle:android-client-sdk:2.0.7")
     }
 }

--- a/ios/devcycle_flutter_client_sdk.podspec
+++ b/ios/devcycle_flutter_client_sdk.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'DevCycle', '1.14.0'
+  s.dependency 'DevCycle', '1.17.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://docs.devcycle.com/docs/sdk/client-side-sdks/flutter
 issue_tracker: https://github.com/DevCycleHQ/flutter-client-sdk/issues
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.14.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
- bump DevCycle Android Client SDK to `2.0.7`
- bump DevCycle iOS Client SDK to `1.17.0`
- update Kotlin (see #134 ) and Gradle (see #135) dependencies based on Dependabot PRs
- update `environment. sdk` to ">=2.14.0 <4.0.0" to support newer versions of Dart
  - this was a recommendation when running `flutter pub publish --dry-run`