### PR TITLE
feat: add apiProxyUrl and eventsApiProxyUrl options to the DevCycle Options Builder

### DIFF
--- a/android/src/main/kotlin/com/devcycle/devcycle_flutter_client_sdk/DevCycleFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/com/devcycle/devcycle_flutter_client_sdk/DevCycleFlutterClientSdkPlugin.kt
@@ -278,7 +278,11 @@ class DevCycleFlutterClientSdkPlugin: FlutterPlugin, MethodCallHandler {
       val disableCustomEventLogging = map["disableCustomEventLogging"] as? Boolean
       if(disableCustomEventLogging is Boolean) builder.disableCustomEventLogging(disableCustomEventLogging)
 
+      val apiProxyUrl = map["apiProxyUrl"] as? String
+      if(apiProxyUrl is String) builder.apiProxyUrl(apiProxyUrl)
 
+      val eventsApiProxyUrl = map["eventsApiProxyUrl"] as? String
+      if(eventsApiProxyUrl is String) builder.eventsApiProxyUrl(eventsApiProxyUrl)
     }
     return builder.build()
   }

--- a/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
@@ -190,6 +190,14 @@ public class SwiftDevCycleFlutterClientSdkPlugin: NSObject, FlutterPlugin {
       optionsBuilder.logLevel(logLevel)
     }
 
+    if let apiProxyUrl = dict["apiProxyUrl"] as? String {
+        optionsBuilder.apiProxyUrl(apiProxyUrl)
+    }
+
+    if let eventsApiProxyUrl = dict["eventsApiProxyUrl"] as? String {
+        optionsBuilder.eventsApiProxyUrl(eventsApiProxyUrl)
+    }
+
     let options = optionsBuilder.build()
     return options
   }

--- a/lib/devcycle_options.dart
+++ b/lib/devcycle_options.dart
@@ -10,6 +10,8 @@ class DevCycleOptions {
   final bool? disableConfigCache;
   final bool? disableRealtimeUpdates;
   final LogLevel? logLevel;
+  final String? apiProxyUrl;
+  final String? eventsApiProxyUrl;
 
   DevCycleOptions._builder(DevCycleOptionsBuilder builder)
       : flushEventsIntervalMs = builder._flushEventsIntervalMs,
@@ -20,7 +22,9 @@ class DevCycleOptions {
         configCacheTTL = builder._configCacheTTL,
         disableConfigCache = builder._disableConfigCache,
         disableRealtimeUpdates = builder._disableRealtimeUpdates,
-        logLevel = builder._logLevel;
+        logLevel = builder._logLevel,
+        apiProxyUrl = builder._apiProxyUrl,
+        eventsApiProxyUrl = builder._eventsApiProxyUrl;
 
   Map<String, dynamic> toCodec() {
     final Map<String, dynamic> result = <String, dynamic>{};
@@ -47,6 +51,12 @@ class DevCycleOptions {
     if (logLevel != null) {
       result['logLevel'] = logLevel?.toString().split('.').last;
     }
+    if (apiProxyUrl != null) {
+      result['apiProxyUrl'] = apiProxyUrl;
+    }
+    if (eventsApiProxyUrl != null) {
+      result['eventsApiProxyUrl'] = eventsApiProxyUrl;
+    }
     return result;
   }
 }
@@ -65,6 +75,8 @@ class DevCycleOptionsBuilder {
   bool? _disableConfigCache;
   bool? _disableRealtimeUpdates;
   LogLevel? _logLevel;
+  String? _apiProxyUrl;
+  String? _eventsApiProxyUrl;
 
   DevCycleOptionsBuilder flushEventsIntervalMs(int flushEventsIntervalMs) {
     _flushEventsIntervalMs = flushEventsIntervalMs;
@@ -78,7 +90,8 @@ class DevCycleOptionsBuilder {
     return this;
   }
 
-  DevCycleOptionsBuilder disableCustomEventLogging(bool disableCustomEventLogging) {
+  DevCycleOptionsBuilder disableCustomEventLogging(
+      bool disableCustomEventLogging) {
     _disableCustomEventLogging = disableCustomEventLogging;
     return this;
   }
@@ -111,6 +124,16 @@ class DevCycleOptionsBuilder {
 
   DevCycleOptionsBuilder logLevel(LogLevel logLevel) {
     _logLevel = logLevel;
+    return this;
+  }
+
+  DevCycleOptionsBuilder apiProxyUrl(String apiProxyUrl) {
+    _apiProxyUrl = apiProxyUrl;
+    return this;
+  }
+
+  DevCycleOptionsBuilder eventsApiProxyUrl(String eventsApiProxyUrl) {
+    _eventsApiProxyUrl = eventsApiProxyUrl;
     return this;
   }
 

--- a/test/dvc_options_test.dart
+++ b/test/dvc_options_test.dart
@@ -12,6 +12,8 @@ void main() {
         .disableConfigCache(false)
         .disableRealtimeUpdates(false)
         .logLevel(LogLevel.debug)
+        .apiProxyUrl("http://api.test.com")
+        .eventsApiProxyUrl("http://events.test.com")
         .build();
     expect(options.flushEventsIntervalMs, equals(100));
     expect(options.disableCustomEventLogging, isTrue);
@@ -21,6 +23,8 @@ void main() {
     expect(options.disableConfigCache, isFalse);
     expect(options.disableRealtimeUpdates, isFalse);
     expect(options.logLevel, equals(LogLevel.debug));
+    expect(options.apiProxyUrl, equals("http://api.test.com"));
+    expect(options.eventsApiProxyUrl, equals("http://events.test.com"));
   });
 
   test('deprecated DVCOptionsBuilder', () {
@@ -33,6 +37,8 @@ void main() {
         .disableConfigCache(false)
         .disableRealtimeUpdates(false)
         .logLevel(LogLevel.debug)
+        .apiProxyUrl("http://api.test.com")
+        .eventsApiProxyUrl("http://events.test.com")
         .build();
     expect(options.flushEventsIntervalMs, equals(100));
     expect(options.disableCustomEventLogging, isTrue);
@@ -42,6 +48,8 @@ void main() {
     expect(options.disableConfigCache, isFalse);
     expect(options.disableRealtimeUpdates, isFalse);
     expect(options.logLevel, equals(LogLevel.debug));
+    expect(options.apiProxyUrl, equals("http://api.test.com"));
+    expect(options.eventsApiProxyUrl, equals("http://events.test.com"));
   });
 
   test('creates map from options object with all properties', () {
@@ -53,6 +61,8 @@ void main() {
         .configCacheTTL(999)
         .disableConfigCache(false)
         .logLevel(LogLevel.error)
+        .apiProxyUrl("http://api.test.com")
+        .eventsApiProxyUrl("http://events.test.com")
         .build();
     Map<String, dynamic> codecOptions = options.toCodec();
     expect(codecOptions['flushEventsIntervalMs'], equals(100));
@@ -62,10 +72,13 @@ void main() {
     expect(codecOptions['configCacheTTL'], equals(999));
     expect(codecOptions['disableConfigCache'], isFalse);
     expect(codecOptions['logLevel'], equals('error'));
+    expect(codecOptions['apiProxyUrl'], equals('http://api.test.com'));
+    expect(codecOptions['eventsApiProxyUrl'], equals('http://events.test.com'));
   });
 
   test('creates map from options object with only one property', () {
-    DevCycleOptions options = DVCOptionsBuilder().flushEventsIntervalMs(100).build();
+    DevCycleOptions options =
+        DVCOptionsBuilder().flushEventsIntervalMs(100).build();
     Map<String, dynamic> codecOptions = options.toCodec();
     expect(codecOptions, {"flushEventsIntervalMs": 100});
   });


### PR DESCRIPTION
- adds apiProxyUrl to DevCycle Options builder to support underlying Android and iOS functionality
- adds eventsApiProxyUrl to DevCycle Options builder to support underlying Android and iOS functionality