### PR TITLE
fix: pass in type for swift to use the correct variable types

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - DevCycle (= 1.17.1)
     - Flutter
   - Flutter (1.0.0)
-  - LDSwiftEventSource (3.1.1)
+  - LDSwiftEventSource (3.3.0)
 
 DEPENDENCIES:
   - devcycle_flutter_client_sdk (from `.symlinks/plugins/devcycle_flutter_client_sdk/ios`)
@@ -24,9 +24,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DevCycle: 024d5912ce21eac46cc5e629aaabeec30218b691
-  devcycle_flutter_client_sdk: 53fcd010d9dc6001207e8fed4295dd193893c23a
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  LDSwiftEventSource: 3f9ff84ca80677f9a4f8596757dcb50026e4a13c
+  devcycle_flutter_client_sdk: 46359fba96436d333d967fb56a07e24107bc47f3
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  LDSwiftEventSource: b0826ca826ca890609a9833a05cae1f357fd3b99
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
@@ -4,278 +4,314 @@ import UIKit
 import DevCycle
 
 public class SwiftDevCycleFlutterClientSdkPlugin: NSObject, FlutterPlugin {
-  private var dvcClient: DVCClient?
-  private let channel: FlutterMethodChannel
-  private var variableUpdates: [String: DVCVariable<Any>] = [:]
+    private var dvcClient: DVCClient?
+    private let channel: FlutterMethodChannel
+    private var variableUpdates: [String: Any] = [:]
+    private let numberTypes = ["int", "double"]
     
-  private init(channel: FlutterMethodChannel) {
-    self.channel = channel
-  }
-  
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "devcycle_flutter_client_sdk", binaryMessenger: registrar.messenger())
-    let instance = SwiftDevCycleFlutterClientSdkPlugin(channel: channel)
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    var user: DVCUser?
-    let args = call.arguments as? [String: Any]
-    let callbackId = args?["callbackId"] as? String
-    var callbackArgs: [String:Any] = [:]
-
-    if let userArg = args?["user"] as? [String: Any] {
-      user = getUserFromDict(dict: userArg)
+    private init(channel: FlutterMethodChannel) {
+        self.channel = channel
     }
     
-    switch call.method {
-    case "initializeDevCycle":
-      let sdkKey = args?["sdkKey"] as? String
-      let options = args?["options"] as? [String: Any]
-      if let dvcUser = user, let dvcKey = sdkKey {
-        self.dvcClient = try? DVCClient.builder()
-          .sdkKey(dvcKey)
-          .user(dvcUser)
-          .options(getOptionsFromDict(dict: options ?? [:] ))
-          .build(onInitialized: { error in
-            if (error != nil) {
-              callbackArgs["error"] = "\(String(describing: error))"
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "devcycle_flutter_client_sdk", binaryMessenger: registrar.messenger())
+        let instance = SwiftDevCycleFlutterClientSdkPlugin(channel: channel)
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+    
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        var user: DVCUser?
+        let args = call.arguments as? [String: Any]
+        let callbackId = args?["callbackId"] as? String
+        var callbackArgs: [String:Any] = [:]
+        
+        if let userArg = args?["user"] as? [String: Any] {
+            user = getUserFromDict(dict: userArg)
+        }
+        
+        switch call.method {
+        case "initializeDevCycle":
+            let sdkKey = args?["sdkKey"] as? String
+            let options = args?["options"] as? [String: Any]
+            if let dvcUser = user, let dvcKey = sdkKey {
+                self.dvcClient = try? DVCClient.builder()
+                    .sdkKey(dvcKey)
+                    .user(dvcUser)
+                    .options(getOptionsFromDict(dict: options ?? [:] ))
+                    .build(onInitialized: { error in
+                        if (error != nil) {
+                            callbackArgs["error"] = "\(String(describing: error))"
+                        }
+                        self.channel.invokeMethod("clientInitialized", arguments: callbackArgs)
+                    })
             }
-            self.channel.invokeMethod("clientInitialized", arguments: callbackArgs)
-        })
-      }
-      result(nil)
-    case "identifyUser":
-      if let dvcUser = user {
-        try? self.dvcClient?.identifyUser(user: dvcUser, callback: { error, variables in
-          callbackArgs["callbackId"] = callbackId
-          if (error != nil) {
-            callbackArgs["error"] = "\(String(describing: error))"
-          } else {
-            callbackArgs["variables"] = self.variablesToMap(variables: variables ?? [:])
-          }
-          self.channel.invokeMethod("userIdentified", arguments: callbackArgs)
-        })
-      }
-      result(nil)
-    case "resetUser":
-      try? self.dvcClient?.resetUser(callback: { error, variables in
-        callbackArgs["callbackId"] = callbackId
-        if (error != nil) {
-          callbackArgs["error"] = "\(String(describing: error))"
+            result(nil)
+        case "identifyUser":
+            if let dvcUser = user {
+                try? self.dvcClient?.identifyUser(user: dvcUser, callback: { error, variables in
+                    callbackArgs["callbackId"] = callbackId
+                    if (error != nil) {
+                        callbackArgs["error"] = "\(String(describing: error))"
+                    } else {
+                        callbackArgs["variables"] = self.variablesToMap(variables: variables ?? [:])
+                    }
+                    self.channel.invokeMethod("userIdentified", arguments: callbackArgs)
+                })
+            }
+            result(nil)
+        case "resetUser":
+            try? self.dvcClient?.resetUser(callback: { error, variables in
+                callbackArgs["callbackId"] = callbackId
+                if (error != nil) {
+                    callbackArgs["error"] = "\(String(describing: error))"
+                } else {
+                    callbackArgs["variables"] = self.variablesToMap(variables: variables ?? [:])
+                }
+                self.channel.invokeMethod("userReset", arguments: callbackArgs)
+            })
+            result(nil)
+        case "allFeatures":
+            result(featuresToMap(features: self.dvcClient?.allFeatures() ?? [:]))
+        case "allVariables":
+            result(variablesToMap(variables: self.dvcClient?.allVariables() ?? [:]))
+        case "getPlatformVersion":
+            result("iOS " + UIDevice.current.systemVersion)
+        case "variable":
+            return getResultForVariable(args: args, callbackArgs: callbackArgs, result: result)
+        case "track":
+            if let event = args?["event"] as? [String: Any], let dvcEvent = getEventFromDict(dict: event) {
+                self.dvcClient?.track(dvcEvent)
+            }
+        case "flushEvents":
+            self.dvcClient?.flushEvents(callback: { error in
+                callbackArgs["callbackId"] = callbackId
+                if (error != nil) {
+                    callbackArgs["error"] = "\(String(describing: error))"
+                }
+                self.channel.invokeMethod("eventsFlushed", arguments: callbackArgs)
+            })
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+    
+    private func getResultForVariable(args: [String: Any]?, callbackArgs: [String:Any], result: @escaping FlutterResult) {
+        guard
+            let dvcClient = self.dvcClient,
+            let varKey = args?["key"] as? String,
+            let varDefaultValue = args?["defaultValue"],
+            let type = args?["type"] as? String
+        else {
+            result(nil)
+            return
+        }
+        
+        if type == "String", let stringDefault = varDefaultValue as? String {
+            let variable = dvcClient.variable(key: varKey, defaultValue: stringDefault)
+            storeVariableInMemory(key: varKey, variable: variable, callbackArgs: callbackArgs)
+            let codecVariable = dvcVariableToMap(variable: variable as DVCVariable<String>)
+            result(codecVariable)
+        } else if type.contains("Map"), let jsonDefault = varDefaultValue as? Dictionary<String, Any> {
+            let variable = dvcClient.variable(key: varKey, defaultValue: jsonDefault)
+            storeVariableInMemory(key: varKey, variable: variable, callbackArgs: callbackArgs)
+            let codecVariable = dvcVariableToMap(variable: variable as DVCVariable<Dictionary<String, Any>>)
+            result(codecVariable)
+        } else if numberTypes.contains(type), let numDefault = varDefaultValue as? Double {
+            let variable = dvcClient.variable(key: varKey, defaultValue: numDefault)
+            storeVariableInMemory(key: varKey, variable: variable, callbackArgs: callbackArgs)
+            let codecVariable = dvcVariableToMap(variable: variable as DVCVariable<Double>)
+            result(codecVariable)
+        } else if type == "bool", let boolDefault = varDefaultValue as? Bool {
+            let variable = dvcClient.variable(key: varKey, defaultValue: boolDefault)
+            storeVariableInMemory(key: varKey, variable: variable, callbackArgs: callbackArgs)
+            let codecVariable = dvcVariableToMap(variable: variable)
+            result(codecVariable)
         } else {
-          callbackArgs["variables"] = self.variablesToMap(variables: variables ?? [:])
+            let variable = dvcClient.variable(key: varKey, defaultValue: varDefaultValue)
+            result(dvcVariableToMap(variable: variable))
         }
-        self.channel.invokeMethod("userReset", arguments: callbackArgs)
-      })
-      result(nil)
-    case "allFeatures":
-        result(featuresToMap(features: self.dvcClient?.allFeatures() ?? [:]))
-    case "allVariables":
-        result(variablesToMap(variables: self.dvcClient?.allVariables() ?? [:]))
-    case "getPlatformVersion":
-      result("iOS " + UIDevice.current.systemVersion)
-    case "variable":
-      if let dvcClient = self.dvcClient, let varKey = args?["key"] as? String, let varDefaultValue = args?["defaultValue"] as? Any {
-        let variable = dvcClient.variable(key: varKey, defaultValue: varDefaultValue)
-        if !self.variableUpdates.contains(where: { $0.key == variable.key }) {
-          variable.onUpdate(handler: { newValue in
-            callbackArgs["key"] = variable.key
-            callbackArgs["value"] = variable.value
-            self.channel.invokeMethod("variableUpdated", arguments: callbackArgs)
-          })
-          self.variableUpdates[variable.key] = variable
+    }
+    
+    private func storeVariableInMemory<T>(key: String, variable: DVCVariable<T>, callbackArgs: [String:Any]) {
+        if !self.variableUpdates.contains(where: { $0.key == key }) {
+            variable.onUpdate(handler: { newValue in
+                var newCallbackArgs = callbackArgs
+                newCallbackArgs["key"] = variable.key
+                newCallbackArgs["value"] = variable.value
+                self.channel.invokeMethod("variableUpdated", arguments: callbackArgs)
+            })
+            self.variableUpdates[variable.key] = variable
         }
-        let codecVariable = dvcVariableToMap(variable: variable)
-        result(codecVariable)
-      } else {
-        result(nil)
-      }
-    case "track":
-      if let event = args?["event"] as? [String: Any], let dvcEvent = getEventFromDict(dict: event) {
-        self.dvcClient?.track(dvcEvent)
-      }
-    case "flushEvents":
-      self.dvcClient?.flushEvents(callback: { error in
-        callbackArgs["callbackId"] = callbackId
-        if (error != nil) {
-          callbackArgs["error"] = "\(String(describing: error))"
+    }
+    
+    private func getUserFromDict(dict: [String: Any?]) -> DVCUser? {
+        let userBuilder = DVCUser.builder()
+        
+        if let userId = dict["userId"] as? String {
+            userBuilder.userId(userId)
         }
-        self.channel.invokeMethod("eventsFlushed", arguments: callbackArgs)
-      })
-      result(nil)
-    default:
-      result(FlutterMethodNotImplemented)
-    }
-  }
-  
-  private func getUserFromDict(dict: [String: Any?]) -> DVCUser? {
-    let userBuilder = DVCUser.builder()
-    
-    if let userId = dict["userId"] as? String {
-      userBuilder.userId(userId)
-    }
-
-    if let isAnonymous = dict["isAnonymous"] as? Bool {
-      userBuilder.isAnonymous(isAnonymous)
-    }
-    
-    if let email = dict["email"] as? String {
-      userBuilder.email(email)
-    }
-    
-    if let name = dict["name"] as? String {
-      userBuilder.name(name)
-    }
-    
-    if let country = dict["country"] as? String {
-      userBuilder.country(country)
+        
+        if let isAnonymous = dict["isAnonymous"] as? Bool {
+            userBuilder.isAnonymous(isAnonymous)
+        }
+        
+        if let email = dict["email"] as? String {
+            userBuilder.email(email)
+        }
+        
+        if let name = dict["name"] as? String {
+            userBuilder.name(name)
+        }
+        
+        if let country = dict["country"] as? String {
+            userBuilder.country(country)
+        }
+        
+        if let customData = dict["customData"] as? [String: Any] {
+            userBuilder.customData(customData)
+        }
+        
+        if let privateCustomData = dict["privateCustomData"] as? [String: Any] {
+            userBuilder.privateCustomData(privateCustomData)
+        }
+        
+        let user = try? userBuilder.build()
+        return user
     }
     
-    if let customData = dict["customData"] as? [String: Any] {
-      userBuilder.customData(customData)
+    private func getOptionsFromDict(dict: [String: Any?]) -> DevCycleOptions {
+        let optionsBuilder = DevCycleOptions.builder()
+        
+        if let flushEventsIntervalMs = dict["flushEventsIntervalMs"] as? Int {
+            optionsBuilder.flushEventsIntervalMs(flushEventsIntervalMs)
+        }
+        
+        if let disableEventLogging = dict["disableEventLogging"] as? Bool {
+            optionsBuilder.disableEventLogging(disableEventLogging)
+        }
+        
+        if let disableAutomaticEventLogging = dict["disableAutomaticEventLogging"] as? Bool {
+            optionsBuilder.disableAutomaticEventLogging(disableAutomaticEventLogging)
+        }
+        
+        if let disableCustomEventLogging = dict["disableCustomEventLogging"] as? Bool {
+            optionsBuilder.disableCustomEventLogging(disableCustomEventLogging)
+        }
+        
+        if let enableEdgeDB = dict["enableEdgeDB"] as? Bool {
+            optionsBuilder.enableEdgeDB(enableEdgeDB)
+        }
+        
+        if let configCacheTTL = dict["configCacheTTL"] as? Int {
+            optionsBuilder.configCacheTTL(configCacheTTL)
+        }
+        
+        if let disableConfigCache = dict["disableConfigCache"] as? Bool {
+            optionsBuilder.disableConfigCache(disableConfigCache)
+        }
+        
+        if let disableRealtimeUpdates = dict["disableRealtimeUpdates"] as? Bool {
+            optionsBuilder.disableRealtimeUpdates(disableRealtimeUpdates)
+        }
+        
+        let logLevelMap = [
+            "debug": LogLevel.debug,
+            "info": LogLevel.info,
+            "warn": LogLevel.warn,
+            "error": LogLevel.error
+        ]
+        
+        if let codecLogLevel = dict["logLevel"] as? String, let logLevel = logLevelMap[codecLogLevel] {
+            optionsBuilder.logLevel(logLevel)
+        }
+        
+        if let apiProxyUrl = dict["apiProxyUrl"] as? String {
+            optionsBuilder.apiProxyURL(apiProxyUrl)
+        }
+        
+        if let eventsApiProxyUrl = dict["eventsApiProxyUrl"] as? String {
+            optionsBuilder.eventsApiProxyURL(eventsApiProxyUrl)
+        }
+        
+        let options = optionsBuilder.build()
+        return options
     }
     
-    if let privateCustomData = dict["privateCustomData"] as? [String: Any] {
-      userBuilder.privateCustomData(privateCustomData)
-    }
-
-    let user = try? userBuilder.build()
-    return user
-  }
-  
-  private func getOptionsFromDict(dict: [String: Any?]) -> DevCycleOptions {
-    let optionsBuilder = DevCycleOptions.builder()
-    
-    if let flushEventsIntervalMs = dict["flushEventsIntervalMs"] as? Int {
-      optionsBuilder.flushEventsIntervalMs(flushEventsIntervalMs)
-    }
-    
-    if let disableEventLogging = dict["disableEventLogging"] as? Bool {
-      optionsBuilder.disableEventLogging(disableEventLogging)
-    }
-
-    if let disableAutomaticEventLogging = dict["disableAutomaticEventLogging"] as? Bool {
-      optionsBuilder.disableAutomaticEventLogging(disableAutomaticEventLogging)
-    }
-
-    if let disableCustomEventLogging = dict["disableCustomEventLogging"] as? Bool {
-      optionsBuilder.disableCustomEventLogging(disableCustomEventLogging)
-    }
-    
-    if let enableEdgeDB = dict["enableEdgeDB"] as? Bool {
-      optionsBuilder.enableEdgeDB(enableEdgeDB)
+    private func getEventFromDict(dict: [String: Any?]) -> DVCEvent? {
+        let eventBuilder = DVCEvent.builder()
+        
+        if let type = dict["type"] as? String {
+            eventBuilder.type(type)
+        }
+        
+        if let target = dict["target"] as? String {
+            eventBuilder.target(target)
+        }
+        
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let dateString = dict["date"] as? String, let date = dateFormatter.date(from: dateString) {
+            eventBuilder.clientDate(date)
+        }
+        
+        if let value = dict["value"] as? String, let doubleValue = Double(value) {
+            eventBuilder.value(doubleValue)
+        }
+        
+        if let metaData = dict["metaData"] as? [String: Any] {
+            eventBuilder.metaData(metaData)
+        }
+        
+        let event = try? eventBuilder.build()
+        return event
     }
     
-    if let configCacheTTL = dict["configCacheTTL"] as? Int {
-      optionsBuilder.configCacheTTL(configCacheTTL)
+    private func variablesToMap(variables: [String: Variable]) -> [String: Any] {
+        var map: [String: Any] = [:]
+        for (key, value) in variables {
+            map[key] = variableToMap(variable: value)
+        }
+        return map
     }
     
-    if let disableConfigCache = dict["disableConfigCache"] as? Bool {
-      optionsBuilder.disableConfigCache(disableConfigCache)
-    }
-      
-    if let disableRealtimeUpdates = dict["disableRealtimeUpdates"] as? Bool {
-        optionsBuilder.disableRealtimeUpdates(disableRealtimeUpdates)
-    }
-    
-    let logLevelMap = [
-      "debug": LogLevel.debug,
-      "info": LogLevel.info,
-      "warn": LogLevel.warn,
-      "error": LogLevel.error
-    ]
-    
-    if let codecLogLevel = dict["logLevel"] as? String, let logLevel = logLevelMap[codecLogLevel] {
-      optionsBuilder.logLevel(logLevel)
-    }
-
-    if let apiProxyUrl = dict["apiProxyUrl"] as? String {
-        optionsBuilder.apiProxyURL(apiProxyUrl)
-    }
-
-    if let eventsApiProxyUrl = dict["eventsApiProxyUrl"] as? String {
-        optionsBuilder.eventsApiProxyURL(eventsApiProxyUrl)
-    }
-
-    let options = optionsBuilder.build()
-    return options
-  }
-  
-  private func getEventFromDict(dict: [String: Any?]) -> DVCEvent? {
-    let eventBuilder = DVCEvent.builder()
-    
-    if let type = dict["type"] as? String {
-      eventBuilder.type(type)
+    private func variableToMap(variable: Variable) -> [String: Any] {
+        var map: [String: Any] = [:]
+        map["id"] = variable._id
+        map["key"] = variable.key
+        map["type"] = variable.type.rawValue
+        map["value"] = variable.value
+        map["evalReason"] = variable.evalReason
+        return map
     }
     
-    if let target = dict["target"] as? String {
-      eventBuilder.target(target)
+    private func dvcVariableToMap<T>(variable: DVCVariable<T>) -> [String: Any] {
+        var map: [String: Any] = [:]
+        map["key"] = variable.key
+        map["type"] = variable.type?.rawValue
+        map["value"] = variable.value
+        map["evalReason"] = variable.evalReason
+        map["isDefaulted"] = variable.isDefaulted
+        return map
     }
     
-    let dateFormatter = ISO8601DateFormatter()
-    dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let dateString = dict["date"] as? String, let date = dateFormatter.date(from: dateString) {
-      eventBuilder.clientDate(date)
+    private func featuresToMap(features: [String: Feature]) -> [String: Any] {
+        var map: [String: Any] = [:]
+        for (key, value) in features {
+            map[key] = featureToMap(feature: value)
+        }
+        return map
     }
     
-    if let value = dict["value"] as? String, let doubleValue = Double(value) {
-      eventBuilder.value(doubleValue)
+    private func featureToMap(feature: Feature) -> [String: String] {
+        var map: [String: String] = [:]
+        map["id"] = feature._id
+        map["key"] = feature.key
+        map["type"] = feature.type
+        map["variation"] = feature._variation
+        map["evalReason"] = feature.evalReason
+        map["variationKey"] = feature.variationKey
+        map["variationName"] = feature.variationName
+        return map
     }
-    
-    if let metaData = dict["metaData"] as? [String: Any] {
-      eventBuilder.metaData(metaData)
-    }
-    
-    let event = try? eventBuilder.build()
-    return event
-  }
-
-  private func variablesToMap(variables: [String: Variable]) -> [String: Any] {
-    var map: [String: Any] = [:]
-    for (key, value) in variables {
-        map[key] = variableToMap(variable: value)
-    }
-    return map
-  }
-
-  private func variableToMap(variable: Variable) -> [String: Any] {
-    var map: [String: Any] = [:]
-    map["id"] = variable._id
-    map["key"] = variable.key
-    map["type"] = variable.type.rawValue
-    map["value"] = variable.value
-    map["evalReason"] = variable.evalReason
-    return map
-  }
-    
-  private func dvcVariableToMap(variable: DVCVariable<Any>) -> [String: Any] {
-    var map: [String: Any] = [:]
-    map["key"] = variable.key
-    map["type"] = variable.type?.rawValue
-    map["value"] = variable.value
-    map["evalReason"] = variable.evalReason
-    map["isDefaulted"] = variable.isDefaulted
-    return map
-  }
-
-  private func featuresToMap(features: [String: Feature]) -> [String: Any] {
-    var map: [String: Any] = [:]
-    for (key, value) in features {
-        map[key] = featureToMap(feature: value)
-    }
-    return map
-  }
-
-  private func featureToMap(feature: Feature) -> [String: String] {
-    var map: [String: String] = [:]
-    map["id"] = feature._id
-    map["key"] = feature.key
-    map["type"] = feature.type
-    map["variation"] = feature._variation
-    map["evalReason"] = feature.evalReason
-    map["variationKey"] = feature.variationKey
-    map["variationName"] = feature.variationName
-    return map
-  }
 }

--- a/lib/devcycle_flutter_client_sdk_method_channel.dart
+++ b/lib/devcycle_flutter_client_sdk_method_channel.dart
@@ -20,17 +20,11 @@ class MethodChannelDevCycleFlutterClientSdk
 
   @override
   Future<void> initializeDevCycle(
-      String sdkKey,
-      DevCycleUser user,
-      DevCycleOptions? options
-  ) async {
+      String sdkKey, DevCycleUser user, DevCycleOptions? options) async {
     Map<String, dynamic> codecUser = user.toCodec();
     Map<String, dynamic>? codecOptions = options?.toCodec();
-    await methodChannel.invokeMethod('initializeDevCycle', {
-      "sdkKey": sdkKey,
-      "user": codecUser,
-      "options": codecOptions
-    });
+    await methodChannel.invokeMethod('initializeDevCycle',
+        {"sdkKey": sdkKey, "user": codecUser, "options": codecOptions});
   }
 
   @override
@@ -47,10 +41,12 @@ class MethodChannelDevCycleFlutterClientSdk
 
   @override
   Future<DVCVariable> variable(String key, dynamic defaultValue) async {
-    final result = await methodChannel.invokeMethod(
-        'variable',
-        {"key": key, "defaultValue": defaultValue}
-    ) ?? {};
+    final result = await methodChannel.invokeMethod('variable', {
+          "key": key,
+          "defaultValue": defaultValue,
+          "type": defaultValue.runtimeType.toString()
+        }) ??
+        {};
     final map = Map<String, dynamic>.from(result);
     return map.isNotEmpty
         ? DVCVariable.fromCodec(map)

--- a/test/devcycle_flutter_client_sdk_test.dart
+++ b/test/devcycle_flutter_client_sdk_test.dart
@@ -69,11 +69,7 @@ void main() {
       DevCycleUser user = DevCycleUserBuilder().userId('user1').build();
       DevCycleOptions options =
           DVCOptionsBuilder().configCacheTTL(100).enableEdgeDB(true).build();
-      DevCycleClientBuilder()
-          .user(user)
-          .sdkKey('123')
-          .options(options)
-          .build();
+      DevCycleClientBuilder().user(user).sdkKey('123').options(options).build();
       expect(methodCall?.method, 'initializeDevCycle');
       expect(methodCall?.arguments, {
         "sdkKey": "123",
@@ -90,7 +86,8 @@ void main() {
     });
 
     test('fails to initialize without a user', () async {
-      DevCycleClientBuilder clientBuilder = DevCycleClientBuilder().sdkKey('123');
+      DevCycleClientBuilder clientBuilder =
+          DevCycleClientBuilder().sdkKey('123');
 
       expect(clientBuilder.build, throwsException);
     });
@@ -155,19 +152,25 @@ void main() {
       await devcycleFlutterClientSdkPlugin.variable(
           'test-key', 'default-value');
       expect(methodCall?.method, 'variable');
-      expect(methodCall?.arguments,
-          {'key': 'test-key', 'defaultValue': 'default-value'});
+      expect(methodCall?.arguments, {
+        'key': 'test-key',
+        'defaultValue': 'default-value',
+        'type': 'String'
+      });
     });
 
     test('get variable value', () async {
       DevCycleUser user = DevCycleUserBuilder().userId('user1').build();
       DevCycleClient devcycleFlutterClientSdkPlugin =
-      DevCycleClientBuilder().sdkKey('SDK_KEY').user(user).build();
+          DevCycleClientBuilder().sdkKey('SDK_KEY').user(user).build();
       await devcycleFlutterClientSdkPlugin.variableValue(
           'test-key', 'default-value');
       expect(methodCall?.method, 'variable');
-      expect(methodCall?.arguments,
-          {'key': 'test-key', 'defaultValue': 'default-value'});
+      expect(methodCall?.arguments, {
+        'key': 'test-key',
+        'defaultValue': 'default-value',
+        'type': 'String'
+      });
     });
   });
 
@@ -195,8 +198,10 @@ void main() {
       DevCycleUser user = DevCycleUserBuilder().userId('user1').build();
       DevCycleClient devcycleFlutterClientSdkPlugin =
           DevCycleClientBuilder().sdkKey('SDK_KEY').user(user).build();
-      DevCycleEvent event =
-          DevCycleEventBuilder().type('my event type').target('my target').build();
+      DevCycleEvent event = DevCycleEventBuilder()
+          .type('my event type')
+          .target('my target')
+          .build();
 
       await devcycleFlutterClientSdkPlugin.track(event);
       expect(methodCall?.method, 'track');
@@ -221,7 +226,7 @@ void main() {
     test('do not track event with disableCustomEventLogging', () async {
       DevCycleUser user = DevCycleUserBuilder().userId('user1').build();
       DevCycleClient devcycleFlutterClientSdkPlugin =
-      DevCycleClientBuilder().sdkKey('SDK_KEY').user(user).build();
+          DevCycleClientBuilder().sdkKey('SDK_KEY').user(user).build();
       DevCycleEvent event = DevCycleEventBuilder()
           .type('my event type')
           .target('my target')


### PR DESCRIPTION
# Changes

- use the correctly typed DVCVariable to prevent defaulting behaviour

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
