### PR TITLE
chore: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/flutter-client-sdk/security/code-scanning/2](https://github.com/DevCycleHQ/flutter-client-sdk/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the steps in the workflow:
- `contents: write` is needed for steps that update files, commit changes, and push to the repository.
- `contents: read` is sufficient for steps that only read repository contents.
- `pull-requests: write` is not explicitly required since the workflow does not interact with pull requests.
- Other permissions (e.g., `actions`, `packages`, `statuses`) are not needed based on the current workflow.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
