### PR TITLE
fix: add namespace to build gradle for newer versions of gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.devcycle.devcycle_flutter_client_sdk"
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
