### PR TITLE
fix: actions permissions

### DIFF
--- a/.github/workflows/update-sdk-versions.yaml
+++ b/.github/workflows/update-sdk-versions.yaml
@@ -8,7 +8,8 @@ on:
     types: [update-dvc-sdks]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   trigger-ios-update:


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
