### PR TITLE
chore: add inputs to update-sdk actions to call from sdk repos

### DIFF
--- a/.github/workflows/update-android-sdk-version.yaml
+++ b/.github/workflows/update-android-sdk-version.yaml
@@ -5,6 +5,11 @@ on:
     - cron: "0 9 * * MON"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      target-version:
+        description: "Specific Android SDK version to update to (optional)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -24,9 +29,15 @@ jobs:
       - name: Fetch latest Android SDK version
         id: android-version
         run: |
-          LATEST_ANDROID_VERSION=$(curl -s https://api.github.com/repos/DevCycleHQ/android-client-sdk/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-          echo "version=$LATEST_ANDROID_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest Android SDK version: $LATEST_ANDROID_VERSION"
+          if [ -n "${{ inputs.target-version }}" ]; then
+            TARGET_VERSION=$(echo "${{ inputs.target-version }}" | sed 's/^v//')
+            echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
+            echo "Using specified Android SDK version: $TARGET_VERSION"
+          else
+            LATEST_ANDROID_VERSION=$(curl -s https://api.github.com/repos/DevCycleHQ/android-client-sdk/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+            echo "version=$LATEST_ANDROID_VERSION" >> $GITHUB_OUTPUT
+            echo "Latest Android SDK version: $LATEST_ANDROID_VERSION"
+          fi
 
       - name: Get current Android SDK version
         id: current-android

--- a/.github/workflows/update-ios-sdk-version.yaml
+++ b/.github/workflows/update-ios-sdk-version.yaml
@@ -5,6 +5,11 @@ on:
     - cron: "0 9 * * MON"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      target-version:
+        description: "Specific iOS SDK version to update to (optional)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -24,9 +29,15 @@ jobs:
       - name: Fetch latest iOS SDK version
         id: ios-version
         run: |
-          LATEST_IOS_VERSION=$(curl -s https://api.github.com/repos/DevCycleHQ/ios-client-sdk/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-          echo "version=$LATEST_IOS_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest iOS SDK version: $LATEST_IOS_VERSION"
+          if [ -n "${{ inputs.target-version }}" ]; then
+            TARGET_VERSION=$(echo "${{ inputs.target-version }}" | sed 's/^v//')
+            echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
+            echo "Using specified iOS SDK version: $TARGET_VERSION"
+          else
+            LATEST_IOS_VERSION=$(curl -s https://api.github.com/repos/DevCycleHQ/ios-client-sdk/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+            echo "version=$LATEST_IOS_VERSION" >> $GITHUB_OUTPUT
+            echo "Latest iOS SDK version: $LATEST_IOS_VERSION"
+          fi
 
       - name: Get current iOS SDK version
         id: current-ios


### PR DESCRIPTION
- Adding inputs so that we can call these actions from the iOS / Android SDK repos


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
