### PR TITLE
fix: update iOS action

### DIFF
--- a/.github/workflows/update-ios-sdk-version.yaml
+++ b/.github/workflows/update-ios-sdk-version.yaml
@@ -76,11 +76,17 @@ jobs:
           cd example
           flutter pub get
 
+      - name: Setup CocoaPods
+        if: steps.check-update.outputs.update-needed == 'true'
+        run: |
+          gem install cocoapods
+          pod setup --silent
+
       - name: Update iOS dependency lock file
         if: steps.check-update.outputs.update-needed == 'true'
         run: |
           cd example/ios
-          pod update DevCycle --repo-update
+          pod install --repo-update
           echo "✅ Updated iOS Podfile.lock for DevCycle ${{ steps.ios-version.outputs.version }}"
 
       - name: Create Pull Request


### PR DESCRIPTION
This pull request updates the workflow for managing iOS SDK dependencies in the `update-ios-sdk-version.yaml` file. The most significant change is the addition of a step to set up CocoaPods before updating the dependency lock file.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
