### PR TITLE
fix: use the updated eval field instead evalReason

### DIFF
--- a/android/src/main/kotlin/com/devcycle/devcycle_flutter_client_sdk/DevCycleFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/com/devcycle/devcycle_flutter_client_sdk/DevCycleFlutterClientSdkPlugin.kt
@@ -326,7 +326,7 @@ class DevCycleFlutterClientSdkPlugin: FlutterPlugin, MethodCallHandler {
     featureAsMap["key"] = feature.key
     featureAsMap["type"] = feature.type.toString()
     featureAsMap["variation"] = feature.variation
-    featureAsMap["evalReason"] = feature.evalReason
+    featureAsMap["eval"] = feature.eval
     featureAsMap["variationName"] = feature.variationName
     featureAsMap["variationKey"] = feature.variationKey
 
@@ -350,7 +350,7 @@ class DevCycleFlutterClientSdkPlugin: FlutterPlugin, MethodCallHandler {
     variableAsMap["key"] = variable.key
     variableAsMap["type"] = variable.type.toString()
     variableAsMap["value"] = value
-    variableAsMap["evalReason"] = variable.evalReason
+    variableAsMap["eval"] = variable.eval
 
     if (value is JSONObject) variableAsMap["value"] = value.toMap()
     if (value is JSONArray) variableAsMap["value"] = value.toMap()
@@ -365,7 +365,7 @@ class DevCycleFlutterClientSdkPlugin: FlutterPlugin, MethodCallHandler {
     variableAsMap["key"] = variable.key
     variableAsMap["type"] = variable.type.toString()
     variableAsMap["value"] = value
-    variableAsMap["evalReason"] = variable.evalReason
+    variableAsMap["eval"] = variable.eval
 
     if (value is JSONObject) variableAsMap["value"] = value.toMap()
     if (value is JSONArray) variableAsMap["value"] = value.toMap()

--- a/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftDevCycleFlutterClientSdkPlugin.swift
@@ -283,7 +283,7 @@ public class SwiftDevCycleFlutterClientSdkPlugin: NSObject, FlutterPlugin {
         map["key"] = variable.key
         map["type"] = variable.type.rawValue
         map["value"] = variable.value
-        map["evalReason"] = variable.evalReason
+        map["eval"] = variable.eval
         return map
     }
     
@@ -292,7 +292,7 @@ public class SwiftDevCycleFlutterClientSdkPlugin: NSObject, FlutterPlugin {
         map["key"] = variable.key
         map["type"] = variable.type?.rawValue
         map["value"] = variable.value
-        map["evalReason"] = variable.evalReason
+        map["eval"] = variable.eval
         map["isDefaulted"] = variable.isDefaulted
         return map
     }
@@ -311,7 +311,7 @@ public class SwiftDevCycleFlutterClientSdkPlugin: NSObject, FlutterPlugin {
         map["key"] = feature.key
         map["type"] = feature.type
         map["variation"] = feature._variation
-        map["evalReason"] = feature.evalReason
+        map["eval"] = feature.eval
         map["variationKey"] = feature.variationKey
         map["variationName"] = feature.variationName
         return map


### PR DESCRIPTION
- fix: update android and ios channels to properly populate eval reasons using the `eval` field instead of deprecated `evalReason`